### PR TITLE
grvt: amend the l2 bridge to allow moving funds to exchange contract …

### DIFF
--- a/l2-contracts/contracts/bridge/L2StandardERC20.sol
+++ b/l2-contracts/contracts/bridge/L2StandardERC20.sol
@@ -19,6 +19,10 @@ contract L2StandardERC20 is ERC20PermitUpgradeable, IL2StandardToken {
         bool ignoreDecimals;
     }
 
+    // Up to 3 parameters can be indexed.
+    // Indexed parameters helps you filter the logs by the indexed parameter
+    event FundExchangeAccount(address indexed account, uint256 amount);
+
     ERC20Getters availableGetters;
 
     /// @dev The decimals of the token, that are used as a value for `decimals` getter function.
@@ -32,6 +36,9 @@ contract L2StandardERC20 is ERC20PermitUpgradeable, IL2StandardToken {
     /// @dev Address of the L1 token that can be deposited to mint this L2 token
     address public override l1Address;
 
+    /// @dev Address of the exchange smart contract. Any funds deposited to L2 will be transferred to the user main account under in this smart contract
+    address public exchangeAddress;
+
     /// @dev Contract is expected to be used as proxy implementation.
     constructor() {
         // Disable initialization to prevent Parity hack.
@@ -43,11 +50,13 @@ contract L2StandardERC20 is ERC20PermitUpgradeable, IL2StandardToken {
     /// @param _l1Address Address of the L1 token that can be deposited to mint this L2 token
     /// @param _data The additional data that the L1 bridge provide for initialization.
     /// In this case, it is packed `name`/`symbol`/`decimals` of the L1 token.
-    function bridgeInitialize(address _l1Address, bytes memory _data) external initializer {
+    function bridgeInitialize(address _l1Address, bytes memory _data, address _exchangeAddress) external initializer {
         require(_l1Address != address(0), "in6"); // Should be non-zero address
         l1Address = _l1Address;
 
         l2Bridge = msg.sender;
+
+        exchangeAddress = _exchangeAddress;
 
         // We parse the data exactly as they were created on the L1 bridge
         (bytes memory nameBytes, bytes memory symbolBytes, bytes memory decimalsBytes) = abi.decode(
@@ -109,6 +118,17 @@ contract L2StandardERC20 is ERC20PermitUpgradeable, IL2StandardToken {
     function bridgeMint(address _to, uint256 _amount) external override onlyBridge {
         _mint(_to, _amount);
         emit BridgeMint(_to, _amount);
+    }
+
+    /// @dev Move the user's fund to their main account under the exchange contract
+    /// @dev We don't directly move the fund in bridgeMint as we want GRVT's backend to be notified of the deposit first. Only after our risk engine has approved the deposit, we move the fund to the user's exchange account by calling this function. This way, we can prevent a state divergent where user balance is updated on chain before it is updated off chain.
+    // TODO: add a record of how much balance we can moved from user's EOA to exchange account
+    
+    function fundExchangeAccount(address _from, uint256 _amount) external {
+        require(_from != exchangeAddress, "invalid sender");
+        require(exchangeAddress != address(0), "invalid grvt address");
+        _transfer(_from, exchangeAddress, _amount);
+        emit FundExchangeAccount(_from, _amount);
     }
 
     /// @dev Burn tokens from a given account.


### PR DESCRIPTION
# What ❔
Amend the L2 bridge to allow moving funds to exchange contract account

## Why ❔
As an exchange, GRVT wants users to be able to funds their account to trade as soon as possible.
Currently, the stock L2 ERC20 bridge and ERC20 Token contracts only allow user to bridge funds from L1 to L2 EOA.
And thus, we will need user to initiate a transaction to send their funds in L2 EOA to GRVT Exchange contract

This is not ideal since every extra step in the funding process is another hurdle that turns user away. This PR propose a change in the 2 contracts below that allows user's funds to be moved to their exchange contract's account
- L2StandardERC20
- L2ERC20Bridge

This PR is a draft that demonstrates how this could be done. Further consideration about security and upgradability needs to be taken care of in future PRs

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
