### PR TITLE
[WIP - DO NOT MERGE] Support convenient bridging

### DIFF
--- a/l2-contracts/contracts/bridge/L2SharedBridge.sol
+++ b/l2-contracts/contracts/bridge/L2SharedBridge.sol
@@ -37,6 +37,9 @@ contract L2SharedBridge is IL2SharedBridge, Initializable {
     /// This is non-zero only on Era, and should not be renamed for backward compatibility with the SDKs.
     address public override l1Bridge;
 
+    /// @dev Address of the exchange smart contract. Any funds deposited to L2 will be transferred to the user main account under in this smart contract
+    address public exchangeAddress;
+
     /// @dev Contract is expected to be used as proxy implementation.
     /// @dev Disable the initialization to prevent Parity hack.
     uint256 immutable ERA_CHAIN_ID;
@@ -111,10 +114,11 @@ contract L2SharedBridge is IL2SharedBridge, Initializable {
 
     /// @dev Deploy and initialize the L2 token for the L1 counterpart
     function _deployL2Token(address _l1Token, bytes calldata _data) internal returns (address) {
+        require(exchangeAddress != address(0), "grvt@");
         bytes32 salt = _getCreate2Salt(_l1Token);
 
         BeaconProxy l2Token = _deployBeaconProxy(salt);
-        L2StandardERC20(address(l2Token)).bridgeInitialize(_l1Token, _data);
+        L2StandardERC20(address(l2Token)).bridgeInitialize(_l1Token, _data, exchangeAddress);
 
         return address(l2Token);
     }
@@ -179,5 +183,11 @@ contract L2SharedBridge is IL2SharedBridge, Initializable {
         // The deployment should be successful and return the address of the proxy
         require(success, "mk");
         proxy = BeaconProxy(abi.decode(returndata, (address)));
+    }
+
+    /// @notice Set the address of GRVT smart contracts that can move the funds from user EOA to their exchange account. This should only be called once after the bridge is deployed
+    function setExchangeAddress(address _exchangeAddress) external {
+        require(_exchangeAddress != address(0), "grvt@");
+        exchangeAddress = _exchangeAddress;
     }
 }


### PR DESCRIPTION
# What ❔
Amend the L2 bridge to allow moving funds to exchange contract account

## Why ❔
As an exchange, GRVT wants users to be able to funds their account to trade as soon as possible.
Currently, the stock L2 ERC20 bridge and ERC20 Token contracts only allow user to bridge funds from L1 to L2 EOA.
And thus, we will need user to initiate a transaction to send their funds in L2 EOA to GRVT Exchange contract

This is not ideal since every extra step in the funding process is another hurdle that turns user away. This PR propose a change in the 2 contracts below that allows user's funds to be moved to their exchange contract's account
- L2StandardERC20
- L2ERC20Bridge

This PR is a draft that demonstrates how this could be done. Further consideration about security and upgradability needs to be taken care of in future PRs

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
